### PR TITLE
Fix LICENSE.txt download url in test

### DIFF
--- a/recipe/SSLTest.cmake
+++ b/recipe/SSLTest.cmake
@@ -1,5 +1,5 @@
 set(FILE_NAME "LICENSE.txt")
-set(DOWNLOAD_URL "https://raw.githubusercontent.com/conda-forge/cmake-feedstock/master/${FILE_NAME}")
+set(DOWNLOAD_URL "https://raw.githubusercontent.com/gpuciio/cmake-feedstock/v3.18.5/${FILE_NAME}")
 set(EXPECTED_SHA256 "1b17a4bbffec8473f2c0be83f697c2e533f8e1170ed74525ceeee24ddd887afd")
 
 file(DOWNLOAD ${DOWNLOAD_URL} ${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}


### PR DESCRIPTION
The url used to download `LICENSE.txt` file in the tests refer to the `master` branch of the upstream project and so is subject to changes. Use fixed url on the fork repository to fix this.